### PR TITLE
fix react 16.9.0 rename componentWillMount -> UNSAFE_componentWillMount

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -20,7 +20,7 @@ class Provider extends React.Component<Props, State> {
     this.state = { activeLocale };
   }
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     const { channel } = this.props;
     channel.on(`${ADDON_ID}/change`, this.onChanged);
   }


### PR DESCRIPTION
use react 16.9.0 up version, has warning

![image](https://user-images.githubusercontent.com/5771353/69842840-ca382a80-129f-11ea-97f5-f565c7b759b1.png)
