### PR TITLE
Fixed active locale showing in tooltip menu

### DIFF
--- a/src/LocaleSelector.tsx
+++ b/src/LocaleSelector.tsx
@@ -70,6 +70,7 @@ export default class LocaleSelector extends React.Component<Props, State> {
       id: l,
       title: l,
       value: l,
+      active: this.state.activeLocale === l,
       // next line fixes stupid storybook error passing loading=false to span el
       loading: null,
       onClick: this.getOnLinkSelected(l)


### PR DESCRIPTION
There is currently a bug, where you dont see selected locale/language in tooltip.
This PR solves it with setting the "active" prop inside getLinks function.

**Currently:**
![image](https://user-images.githubusercontent.com/39954604/70309599-27872b00-180e-11ea-9299-1bd1cbe2b4c6.png)

**Fix:**
![image](https://user-images.githubusercontent.com/39954604/70309883-d0ce2100-180e-11ea-9b39-5b433cccabd9.png)
